### PR TITLE
Lower minimum version requirements to allow docker build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.5.0)
 project(rpc VERSION 2.2.1)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
Since we are using a Ubuntu 16.04 docker image to build Highlands for
Linux we have to lower the CMake version requirements to 3.5.0.

This project doesn't even use any newer feature, so no worries.