### PR TITLE
examples: Add pthread link time dependency

### DIFF
--- a/examples/calculator/CMakeLists.txt
+++ b/examples/calculator/CMakeLists.txt
@@ -2,11 +2,12 @@ cmake_minimum_required(VERSION 3.0.0)
 project(calculator)
 
 find_package(rpclib REQUIRED)
+find_package(Threads REQUIRED)
 
 include_directories(${RPCLIB_INCLUDE_DIR})
 
 add_executable(calculator_server calculator_server.cc)
-target_link_libraries(calculator_server ${RPCLIB_LIBS})
+target_link_libraries(calculator_server ${RPCLIB_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(
         calculator_server
         PROPERTIES
@@ -15,7 +16,7 @@ set_target_properties(
 target_compile_definitions(calculator_server PUBLIC ${RPCLIB_COMPILE_DEFINITIONS})
 
 add_executable(calculator_client calculator_client.cc)
-target_link_libraries(calculator_client ${RPCLIB_LIBS})
+target_link_libraries(calculator_client ${RPCLIB_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(
         calculator_client
         PROPERTIES

--- a/examples/echo/CMakeLists.txt
+++ b/examples/echo/CMakeLists.txt
@@ -2,11 +2,12 @@ cmake_minimum_required(VERSION 3.0.0)
 project(echo)
 
 find_package(rpclib REQUIRED)
+find_package(Threads REQUIRED)
 
 include_directories(${RPCLIB_INCLUDE_DIR})
 
 add_executable(echo_server echo_server.cc)
-target_link_libraries(echo_server ${RPCLIB_LIBS})
+target_link_libraries(echo_server ${RPCLIB_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(
         echo_server
         PROPERTIES
@@ -15,7 +16,7 @@ set_target_properties(
 target_compile_definitions(echo_server PUBLIC ${RPCLIB_COMPILE_DEFINITIONS})
 
 add_executable(echo_client echo_client.cc)
-target_link_libraries(echo_client ${RPCLIB_LIBS})
+target_link_libraries(echo_client ${RPCLIB_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(
         echo_client
         PROPERTIES


### PR DESCRIPTION
Compiling the calculator and echo examples fail on a Linux system due
to missing pthread library during linking. Add this dependency.