### PR TITLE
Turn into a Nix package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ reference.md
 
 CMakeFiles
 CMakeCache.txt
+
+# IntelliJ & friends
+.idea
+
+# Nix
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,5 @@
+with import <nixpkgs> { };
+
+callPackage ./derivation.nix { } {
+  version = "2.2.1";
+}

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,3 @@
 with import <nixpkgs> { };
 
-callPackage ./derivation.nix { } {
-  version = "2.2.1";
-}
+callPackage ./package.nix { }

--- a/derivation.nix
+++ b/derivation.nix
@@ -1,0 +1,19 @@
+{ stdenv
+, cmake
+}:
+
+{ version }:
+
+stdenv.mkDerivation {
+  name = "rpclib-${version}";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  src = ./.;
+}

--- a/package.nix
+++ b/package.nix
@@ -3,8 +3,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.2.1";
   name = "rpclib-${version}";
+  version = "2.2.1";
 
   nativeBuildInputs = [
     cmake

--- a/package.nix
+++ b/package.nix
@@ -2,9 +2,8 @@
 , cmake
 }:
 
-{ version }:
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  version = "2.2.1";
   name = "rpclib-${version}";
 
   nativeBuildInputs = [


### PR DESCRIPTION
For details on Nix, see https://github.com/ascentai/nixpkgs-ascent

These changes allow building rpclib in an isolated environment using the following command (inside the repo):
```
nix-build
```

People can also install and depend on rpclib without checking out the repo, e.g.:
```
nix-shell --option sandbox false -p ascentPackages.rpclib-2_1_1
```

See our internal package descriptor here: https://github.com/ascentai/nixpkgs-ascent/blob/2ac2f7a386caff9f9ca334e14228376472cc0962/default.nix#L10